### PR TITLE
reference https resources so Chrome will load them (eg., jQuery)

### DIFF
--- a/blackmarket/index.html
+++ b/blackmarket/index.html
@@ -6,7 +6,7 @@
   <link href="favicon.ico" rel="icon" type="image/x-icon" />
   <title>Blackmarket - Incremental-game</title>
 
-  <script src="http://code.jquery.com/jquery-2.1.4.min.js"></script>
+  <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
   <link rel="stylesheet" href="src/paper.bootstrap.css">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">

--- a/blackmarket/src/analytics.js
+++ b/blackmarket/src/analytics.js
@@ -1,7 +1,7 @@
 	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 	  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 	  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	  })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
+	  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
 	  ga('create', 'UA-54540685-10', 'auto');
 	  ga('send', 'pageview');

--- a/blackmarket/src/paper.bootstrap.css
+++ b/blackmarket/src/paper.bootstrap.css
@@ -1,4 +1,4 @@
-@import url("http://fonts.googleapis.com/css?family=Roboto:300,400,500");
+@import url("https://fonts.googleapis.com/css?family=Roboto:300,400,500");
 
 html {
   font-family: sans-serif;


### PR DESCRIPTION
Chrome is throwing Mixed Content errors instead of loading some resources - notably, jQuery - over http when the page itself is loaded over https.

These changes should fix that by loading those resources over https.